### PR TITLE
Fix navigation crash with empty SD listings

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -836,8 +836,8 @@ void handleWriteCard() {
     display.display();
 
     // Handle navigation
-    if (btnUpPressed)    sel = (sel + fileCount - 1) % fileCount;
-    if (btnDownPressed)  sel = (sel + 1) % fileCount;
+    if (btnUpPressed && fileCount > 0)    sel = (sel + fileCount - 1) % fileCount;
+    if (btnDownPressed && fileCount > 0)  sel = (sel + 1) % fileCount;
     if (btnBackPressed)  { fileCount = sel = 0; resetButtons(); currentMenu = MAIN_MENU; displayMainMenu(); return; }
 
     // Handle selection
@@ -965,7 +965,6 @@ void handleBruteForce() {
       
       // Start brute force attack
       bruteForce.isActive = true;
-      bruteForce.startTime = millis();
       bruteForce.startTime = millis();
       
       displayBruteForceStarted();
@@ -1250,8 +1249,8 @@ void handleEmulateCard() {
     }
     display.display();
 
-    if (btnUpPressed)    sel = (sel + fileCount - 1) % fileCount;
-    if (btnDownPressed)  sel = (sel + 1) % fileCount;
+    if (btnUpPressed && fileCount > 0)    sel = (sel + fileCount - 1) % fileCount;
+    if (btnDownPressed && fileCount > 0)  sel = (sel + 1) % fileCount;
     if (btnBackPressed)  { fileCount = sel = 0; currentMenu = MAIN_MENU; displayMainMenu(); return; }
 
     if (btnSelectPressed) {
@@ -1367,8 +1366,8 @@ void handleCardManager() {
   display.display();
 
   // nav
-  if (btnUpPressed)    sel = (sel + fileCount - 1) % fileCount;
-  if (btnDownPressed)  sel = (sel + 1) % fileCount;
+  if (btnUpPressed && fileCount > 0)    sel = (sel + fileCount - 1) % fileCount;
+  if (btnDownPressed && fileCount > 0)  sel = (sel + 1) % fileCount;
   if (btnBackPressed)  { fileCount = sel = 0; resetButtons(); currentMenu = MAIN_MENU; displayMainMenu(); return; }
 
   // delete on SELECT


### PR DESCRIPTION
## Summary
- avoid modulo by zero when navigating empty file lists
- remove duplicate brute force timer initialization

## Testing
- `python3 -m platformio run`

------
https://chatgpt.com/codex/tasks/task_e_686768a296ec832fa23e1ca7f5beecd4