### PR TITLE
Improve web GUI with mode controls

### DIFF
--- a/data/app.js
+++ b/data/app.js
@@ -1,16 +1,39 @@
+async function refreshStatus() {
+  try {
+    const res = await fetch('/api/status');
+    const json = await res.json();
+    document.getElementById('currentMode').textContent = json.mode;
+    document.getElementById('lastUid').textContent = json.uid || '—';
+    document.getElementById('dumpArea').textContent =
+      (json.dump || []).map(b => b.toString(16).padStart(2, '0')).join(' ');
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+document.getElementById('refreshBtn').addEventListener('click', refreshStatus);
+
 document.getElementById('readBtn').addEventListener('click', async () => {
   document.getElementById('dumpArea').textContent = 'Reading…';
   try {
-    // POST to trigger a read
     let res = await fetch('/api/read', { method: 'POST' });
     let json = await res.json();
-
-    // update UID
     document.getElementById('lastUid').textContent = json.uid;
-    // show dump as hex
     document.getElementById('dumpArea').textContent =
-      json.data.map(b => b.toString(16).padStart(2,'0')).join(' ');
+      json.data.map(b => b.toString(16).padStart(2, '0')).join(' ');
   } catch (err) {
     document.getElementById('dumpArea').textContent = 'Error: ' + err;
   }
 });
+
+document.getElementById('setModeBtn').addEventListener('click', async () => {
+  const mode = document.getElementById('modeSelect').value;
+  await fetch('/api/mode', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'mode=' + encodeURIComponent(mode)
+  });
+  refreshStatus();
+});
+
+window.addEventListener('load', refreshStatus);

--- a/data/index.html
+++ b/data/index.html
@@ -8,7 +8,24 @@
 <body>
   <h1>nfcGOD Control Panel</h1>
 
+  <section id="control">
+    <h2>Mode</h2>
+    <select id="modeSelect">
+      <option value="read">Read Card</option>
+      <option value="write">Write Card</option>
+      <option value="emulate">Emulate Card</option>
+      <option value="brute_force">Brute Force</option>
+      <option value="card_manager">Card Manager</option>
+      <option value="settings">Settings</option>
+      <option value="main_menu">Main Menu</option>
+    </select>
+    <button id="setModeBtn">Set Mode</button>
+    <button id="refreshBtn">Refresh</button>
+  </section>
+
   <section id="status">
+    <h2>Status</h2>
+    <p>Current Mode: <span id="currentMode">—</span></p>
     <button id="readBtn">Read Card</button>
     <p>Last UID: <span id="lastUid">—</span></p>
     <pre id="dumpArea"></pre>

--- a/data/style.css
+++ b/data/style.css
@@ -16,3 +16,6 @@ button {
   height: 200px;
   overflow: auto;
 }
+section {
+  margin-bottom: 1.5em;
+}


### PR DESCRIPTION
## Summary
- extend main firmware to expose `/api/status` and `/api/mode` endpoints
- add helpers to map between menu state and strings
- redesign `index.html` with mode controls and status information
- update javascript logic for refresh and setting mode
- tweak CSS styling

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_68676bceb170832fa81c554ebf5edd01